### PR TITLE
.envrc を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ web_modules/
 .env
 .env.*
 !.env.example
+.envrc
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
## 概要
direnv の設定ファイル `.envrc` を `.gitignore` に追加しました。

## 変更内容
- `.gitignore` に `.envrc` を追加
- ローカル環境の設定ファイルをバージョン管理から除外

## テストプラン
- [ ] `.envrc` ファイルが git で無視されることを確認
- [ ] 既存の `.gitignore` の動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)